### PR TITLE
Additional input for config repository specific extraheader

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   endpoint:
     description: gh-federation lambda endpoint
     required: true
+  repos:
+    description: gh-federation repositories
+    default: ''
 
 runs:
   using: "composite"
@@ -36,3 +39,16 @@ runs:
         git config --global --add credential.helper store
         echo $'protocol=https\nhost=github.com\nusername=x-access-token\npassword='"${GH_FEDERATION_ACCESS_TOKEN}"$'\n' | \
           git credential-store store
+
+    - name: Store access token for repos as extraheader
+      if: inputs.repos != ''
+      shell: bash
+      env:
+        REPOS: ${{ inputs.repos }}
+      run: |
+        TOKEN=$(echo -n "x-access-token:${GH_FEDERATION_ACCESS_TOKEN}" | base64)
+        echo "::add-mask::${TOKEN}"
+        for repo in ${REPOS}; do
+          echo "config extraheader for ${repo}"
+          git config --global "http.https://github.com/${repo}.extraheader" "Authorization: Basic ${TOKEN}"
+        done

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: true
   repos:
     description: gh-federation repositories
-    default: ''
+    default: ""
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -50,5 +50,5 @@ runs:
         echo "::add-mask::${TOKEN}"
         for repo in ${REPOS}; do
           echo "config extraheader for ${repo}"
-          git config --global "http.https://github.com/${repo}.extraheader" "Authorization: Basic ${TOKEN}"
+          git config --global "http.${GITHUB_SERVER_URL}/${repo}.extraheader" "Authorization: Basic ${TOKEN}"
         done


### PR DESCRIPTION
This patch implements additional input `repos` for configure extraheader to specific repositories.

It enables checkout internal submodules with gh-federation token via `actions/checkout` like below.
```yaml
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: arkedge/gh-federation@v3.1.0
        with:
          endpoint: <gh-federation endpoint>
          repos: |
            arkedge/internal-repo1
            arkedge/internal-repo2
      - name: checkout  # checkout with internal submodule repositories
        uses: actions/checkout@v3
        with:
          submodules: recursive
```