### PR TITLE
impl retry in client side

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   endpoint:
     description: gh-federation lambda endpoint
     required: true
+  retry_max:
+    description: max retry count
+    default: "5"
   repos:
     description: gh-federation repositories
     default: ""
@@ -16,21 +19,31 @@ runs:
     - uses: actions/github-script@v6
       env:
         GH_FEDERATION_ENDPOINT: ${{ inputs.endpoint }}
+        RETRY_MAX: ${{ inputs.retry_max }}
       with:
         script: |
+          const RETRY_MAX = parseInt(process.env["RETRY_MAX"], 10);
           const idToken = await core.getIDToken();
           const hook = (request, route) => {
             const endpoint = request.endpoint.merge(route);
             endpoint.headers.authorization = `Bearer ${idToken}`;
             return request(endpoint);
           };
-          const { data } = await github.request("POST /token", {
-            baseUrl: process.env["GH_FEDERATION_ENDPOINT"],
-            request: { hook },
-          });
-          const accessToken = data["token"];
-          core.setSecret(accessToken);
-          core.exportVariable("GH_FEDERATION_ACCESS_TOKEN", accessToken);
+
+          for (let i = 0; i < RETRY_MAX; ++i) {
+            try {
+              const { data } = await github.request("POST /token", {
+                baseUrl: process.env["GH_FEDERATION_ENDPOINT"],
+                request: { hook },
+              });
+              const accessToken = data["token"];
+              core.setSecret(accessToken);
+              core.exportVariable("GH_FEDERATION_ACCESS_TOKEN", accessToken);
+              break;
+            } catch (e) {
+              continue;
+            }
+          }
 
     - name: Store access token
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ runs:
               core.exportVariable("GH_FEDERATION_ACCESS_TOKEN", accessToken);
               break;
             } catch (e) {
+              console.log(`retrying (remain: ${RETRY_MAX - i})...`);
               continue;
             }
           }


### PR DESCRIPTION
* https://github.com/arkedge/gh-federation/issues/31

Almost errors caused by inconsistency in JWT timestamp.
Appears to be happening because the time between token acquisition and request is too short.
Inserting delay is a practical solution. But retrying is simpler than it and retrying requires additional cost if only if first request is failed.