### PR TITLE
Add flexibility with respect to suffix '.git' in repository URL.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,5 +66,6 @@ runs:
         echo "::add-mask::${TOKEN}"
         for repo in ${REPOS}; do
           echo "config extraheader for ${repo}"
-          git config --global "http.${GITHUB_SERVER_URL}/${repo}.extraheader" "Authorization: Basic ${TOKEN}"
+          git config --global "http.${GITHUB_SERVER_URL}/${repo%.git}.extraheader" "Authorization: Basic ${TOKEN}"
+          git config --global "http.${GITHUB_SERVER_URL}/${repo%.git}.git.extraheader" "Authorization: Basic ${TOKEN}"
         done


### PR DESCRIPTION
Added `.extraheader` settings to `.gitconfig` for those with and without `.git`, regardless of whether `.git` present in the `repos`  suffix or not.

## Why it works well

When a repository is created, GitHub automatically and recursively removes the suffix `.git` from the repository name.
And GitHub considers the repository names with and without suffix `.git` to be identical.
Therefore, all repositories have only 2 names: with a `.git` extension or not.

`gh-federation` can cover all possible aliases by generating names with and without the `.git` suffix from the repository name in the `repos`, and configuring for them.

And, no security issue arise. This is because the name generated by this method, always mean the same repository.