### PR TITLE
Update actions/github-script from v7 to v8 for Node.js 24 compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         GH_FEDERATION_ENDPOINT: ${{ inputs.endpoint }}
         RETRY_MAX: ${{ inputs.retry_max }}


### PR DESCRIPTION
Node.js 20 のdeprecation 対応
